### PR TITLE
Add dockerized version of the installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,54 @@ Apache Kafka is used for building real-time data pipelines and streaming apps. I
 
 ![Kafka Diagram](./art/kafkaDiagram.png)
 
-## Install Apache Kafka
+This highly-scalable publish-subscribe messaging system that can serve as the data backbone in distributed applications. With Kafka’s Producer-Consumer model it becomes easy to implement multiple data consumers that do live monitoring as well persistent data storage for later analysis.
 
-Apache **Kafka** is a highly-scalable publish-subscribe messaging system that can serve as the data backbone in distributed applications. With Kafka’s Producer-Consumer model it becomes easy to implement multiple data consumers that do live monitoring as well persistent data storage for later analysis.
+## Install Apache Kafka with Docker
+
+Thanks to the usage of docker we can simplify the usage of Kafka for this playground. You just need to move to the folder named ``docker`` and start all the required instances.
+
+```
+cd docker
+docker-compose up
+```
+
+This might take a while, so I'd recommend you to grab a :cofee:.
+
+After that, a Zookeeper instance and a Kafka broker will be initialized. Once the instances are up and running you can test the execution by running the following comands:
+
+```
+# Create topic
+docker-compose exec broker kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic users 
+
+# Start posting messages to the already created topic
+docker-compose exec broker kafka-console-producer --topic=users --broker-list localhost:9092
+
+# Start listening messages from the already created tpic
+docker-compose exec broker kafka-console-consumer --bootstrap-server localhost:9092 --topic users --from-beginning
+```
+
+**If everything goes ok, you'll see how the consumer shows every message the producer posted.**
+
+If you want to access this information from outside the Docker container you can use the ip and port listed when executing ``docker-compose ps``.
+
+```
+  Name               Command            State                        Ports
+------------------------------------------------------------------------------------------------
+broker      /etc/confluent/docker/run   Up      0.0.0.0:29092->29092/tcp, 0.0.0.0:9092->9092/tcp
+zookeeper   /etc/confluent/docker/run   Up      0.0.0.0:2181->2181/tcp, 2888/tcp, 3888/tcp
+```
+
+The broker is accessible from the ip address ``localhost:29092``. If you install the Kafka binaries locally (you can read the following section) or you want to connect from any code you wrote, you can use that ip address and port. This is an example of how to use a console producer and consumer from outside the Docker container.
+
+```
+# Start posting messages to the already created topic
+kafka-console-producer --topic=users --broker-list localhost:29092
+
+# Start listening messages from the already created tpic
+kafka-console-consumer --bootstrap-server localhost:29092 --topic users --from-beginning
+```
+
+## Install Apache Kafka (local)
 
 The best way to install the latest version of the Kafka server on OS X and to keep it up to date is via Homebrew.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,35 @@
+---
+version: '2'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.0.0
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-enterprise-kafka:5.0.0
+    hostname: broker
+    container_name: broker
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:9092
+      CONFLUENT_METRICS_REPORTER_ZOOKEEPER_CONNECT: zookeeper:2181
+      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
+      CONFLUENT_METRICS_ENABLE: 'true'
+      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'


### PR DESCRIPTION
### :tophat: What is the goal?

Let the playground users install Kafka using Docker instead of the raw binaries.

### How is it being implemented?

Using the official [confluent.io](https://www.confluent.io/) docker images for Zookeeper and Kafka we've created a simple ``docker-compose.yml`` file we can use to start a Zookeeper cluster instance with just one broker running Kafka.

We've also documented the whole process so anyone can use these instances as a producer or a consumer easily.

### How can it be tested?

There are no tests for now 😃 
